### PR TITLE
Implement upgrade for RawSeqLock and its ReadGuard

### DIFF
--- a/lock/src/seqlock.rs
+++ b/lock/src/seqlock.rs
@@ -190,10 +190,15 @@ impl<'s, T> ReadGuard<'s, T> {
     }
 
     pub fn upgrade(self) -> Result<WriteGuard<'s, T>, ()> {
-        let Self { lock, seq } = self;
-        let seq = unsafe { lock.lock.upgrade(seq)? };
+        let seq = unsafe { self.lock.lock.upgrade(self.seq)? };
 
-        Ok(WriteGuard { lock, seq })
+        let res = WriteGuard {
+            lock: self.lock,
+            seq,
+        };
+
+        mem::forget(self);
+        Ok(res)
     }
 }
 


### PR DESCRIPTION
 - ~~Use `UnsafeCell` in `SeqLock` for mutable borrowing in `WriteGuard`.~~
 - Add method `upgrade` for `ReadGuard`, to upgrade toward `WriteGuard`.